### PR TITLE
Make clippy warnings actually fail CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,5 +12,6 @@ jobs:
             override: true
       - uses: actions-rs/clippy-check@v1
         with:
+          # https://github.com/actions-rs/clippy-check/issues/2#issuecomment-538671632
+          args: -- -D warnings
           token: ${{ secrets.GITHUB_TOKEN }}
-          # args: --all-features # can't enable all features on stable

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -264,7 +264,7 @@ pub fn format_signed_amount(amount: SignedAmount) -> String {
         let mut string = amount.to_string();
         string.insert(string.len() - 7, ' ');
         string.insert(string.len() - 11, ' ');
-        let string = string.trim_end_matches(" BTC").trim_start_matches("-");
+        let string = string.trim_end_matches(" BTC").trim_start_matches('-');
         if amount.is_negative() {
             format!("-{}", string)
         } else {


### PR DESCRIPTION
we have a clippy problem in master but it's not being picked up. Let's see if this works.