### PR TITLE
Emoji macros

### DIFF
--- a/src/betting/wallet_impls/spend_won.rs
+++ b/src/betting/wallet_impls/spend_won.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, wallet::GunWallet, FeeSpec};
+use crate::{betting::*, wallet::GunWallet, FeeSpec, elog};
 use bdk::{
     bitcoin::{
         util::psbt::{self, PartiallySignedTransaction as Psbt},
@@ -62,7 +62,7 @@ impl GunWallet {
             .filter_map(|result| match result {
                 Ok(ok) => Some(ok),
                 Err(e) => {
-                    eprintln!("Eror with entry in database: {}", e);
+                    elog!(@explosion "Error with entry in database: {}", e);
                     None
                 }
             })

--- a/src/betting/wallet_impls/spend_won.rs
+++ b/src/betting/wallet_impls/spend_won.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, wallet::GunWallet, FeeSpec, elog};
+use crate::{betting::*, elog, wallet::GunWallet, FeeSpec};
 use bdk::{
     bitcoin::{
         util::psbt::{self, PartiallySignedTransaction as Psbt},

--- a/src/betting/wallet_impls/spend_won.rs
+++ b/src/betting/wallet_impls/spend_won.rs
@@ -62,7 +62,7 @@ impl GunWallet {
             .filter_map(|result| match result {
                 Ok(ok) => Some(ok),
                 Err(e) => {
-                    elog!(@explosion "Error with entry in database: {}", e);
+                    elog!(@recoverable_error "Error with entry in database: {}", e);
                     None
                 }
             })

--- a/src/betting/wallet_impls/state_machine.rs
+++ b/src/betting/wallet_impls/state_machine.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, wallet::GunWallet, elog};
+use crate::{betting::*, elog, wallet::GunWallet};
 use anyhow::{anyhow, Context};
 use bdk::blockchain::{
     Blockchain, Broadcast, GetInputState, InputState, TransactionState, TxState,

--- a/src/betting/wallet_impls/state_machine.rs
+++ b/src/betting/wallet_impls/state_machine.rs
@@ -187,7 +187,7 @@ impl GunWallet {
                     },
                     TxState::NotFound => {
                         elog!(
-                            @information
+                            @info
                             "The bet tx for {} has fallen out of mempool -- rebroadcasting it!",
                             bet_id
                         );

--- a/src/betting/wallet_impls/state_machine.rs
+++ b/src/betting/wallet_impls/state_machine.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, wallet::GunWallet};
+use crate::{betting::*, wallet::GunWallet, elog};
 use anyhow::{anyhow, Context};
 use bdk::blockchain::{
     Blockchain, Broadcast, GetInputState, InputState, TransactionState, TxState,
@@ -186,7 +186,8 @@ impl GunWallet {
                         BetState::Included { bet,..} => BetState::Included { bet, height }
                     },
                     TxState::NotFound => {
-                        eprintln!(
+                        elog!(
+                            @information
                             "The bet tx for {} has fallen out of mempool -- rebroadcasting it!",
                             bet_id
                         );

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use bdk::blockchain::esplora::EsploraBlockchainConfig;
-use gun_wallet::cmd::{self, *};
+use gun_wallet::{cmd::{self, *}, elog};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -69,7 +69,8 @@ fn main() -> anyhow::Result<()> {
                     concurrency,
                     ..
                 } = config.blockchain_config();
-                eprintln!(
+                elog!(
+                    @information
                     "syncing wallet with {} (stop_gap: {}, parallel_connections: {})",
                     base_url,
                     stop_gap,

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -1,6 +1,9 @@
 use anyhow::anyhow;
 use bdk::blockchain::esplora::EsploraBlockchainConfig;
-use gun_wallet::{cmd::{self, *}, elog};
+use gun_wallet::{
+    cmd::{self, *},
+    elog,
+};
 use std::path::PathBuf;
 use structopt::StructOpt;
 

--- a/src/bin/gun.rs
+++ b/src/bin/gun.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
                     ..
                 } = config.blockchain_config();
                 elog!(
-                    @information
+                    @info
                     "syncing wallet with {} (stop_gap: {}, parallel_connections: {})",
                     base_url,
                     stop_gap,

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -3,11 +3,11 @@ use crate::{
     betting::*,
     cmd::{self, read_yn, sanitize_str, CmdOutput},
     database::GunDatabase,
-    item,
+    elog, item,
     keychain::Keychain,
     psbt_ext::PsbtFeeRate,
     wallet::GunWallet,
-    OracleInfo, Url, ValueChoice, elog,
+    OracleInfo, Url, ValueChoice,
 };
 use anyhow::{anyhow, Context};
 use bdk::bitcoin::{Address, Amount, Script};
@@ -256,8 +256,8 @@ pub fn run_bet_cmd(
             let local_proposal = wallet.make_proposal(oracle_id, oracle_event, args, keychain)?;
             if let Some(change) = &local_proposal.change {
                 elog!(
-                    @information 
-                    "This proposal will put {} “in-use” unnecessarily because the bet value {} does not match a sum of available utxos.\nYou can get a utxo with the exact amount using `gun split` first.\n--",  
+                    @information
+                    "This proposal will put {} “in-use” unnecessarily because the bet value {} does not match a sum of available utxos.\nYou can get a utxo with the exact amount using `gun split` first.\n--",
                     change.value(), local_proposal.proposal.value
                 );
             }
@@ -388,7 +388,7 @@ pub fn run_bet_cmd(
                     encrypted_offer.to_string_padded(pad, &mut cipher);
                 if overflow > 0 && pad != 0 {
                     elog!(
-                        @warning 
+                        @warning
                         "ciphertext is longer than {} by {} bytes so it will look unusually big",
                         pad, overflow
                     );
@@ -415,8 +415,8 @@ pub fn run_bet_cmd(
                         // remove control characters to prevent tricks.
                         sanitize_str(&mut message);
                         elog!(
-                            @information 
-                            "This message was attached to the offer:\n#### START MESSAGE ####\n{}\n#### END MESSAGE ####", 
+                            @information
+                            "This message was attached to the offer:\n#### START MESSAGE ####\n{}\n#### END MESSAGE ####",
                             message
                         );
                     }
@@ -466,9 +466,9 @@ pub fn run_bet_cmd(
                             if let Err(e) = wallet.take_next_action(id, false) {
                                 elog!(
                                     @explosion
-                                    "Error updating state of bet {} after broadcasting claim tx {}: {}", 
+                                    "Error updating state of bet {} after broadcasting claim tx {}: {}",
                                     id, txid, e
-                                );                            
+                                );
                             }
                         }
                     }
@@ -497,9 +497,9 @@ pub fn run_bet_cmd(
                         if let Err(e) = wallet.take_next_action(id, true) {
                             elog!(
                                 @explosion
-                                "Error updating state of bet {} after broadcasting cancel tx: {}: {}", 
+                                "Error updating state of bet {} after broadcasting cancel tx: {}: {}",
                                 id, txid, e
-                            );                        
+                            );
                         }
                     }
                 }
@@ -729,7 +729,7 @@ pub fn run_bet_cmd(
             let message = message.unwrap_or_else(|| {
                 use std::io::Read;
                 let mut words = String::new();
-                elog!(@suggestion "Type your reply and use CTRL-D to finish it.");                
+                elog!(@suggestion "Type your reply and use CTRL-D to finish it.");
                 std::io::stdin().read_to_string(&mut words).unwrap();
                 words
             });
@@ -737,7 +737,7 @@ pub fn run_bet_cmd(
             let (ciphertext_str, overflow) = ciphertext.to_string_padded(pad, &mut cipher);
             if overflow > 0 && pad != 0 {
                 elog!(
-                    @warning 
+                    @warning
                     "Ciphertext is longer than {} by {} bytes so it will look unusually big",
                     pad, overflow
                 );

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -256,7 +256,7 @@ pub fn run_bet_cmd(
             let local_proposal = wallet.make_proposal(oracle_id, oracle_event, args, keychain)?;
             if let Some(change) = &local_proposal.change {
                 elog!(
-                    @information
+                    @info
                     "This proposal will put {} “in-use” unnecessarily because the bet value {} does not match a sum of available utxos.\nYou can get a utxo with the exact amount using `gun split` first.\n--",
                     change.value(), local_proposal.proposal.value
                 );
@@ -415,7 +415,7 @@ pub fn run_bet_cmd(
                         // remove control characters to prevent tricks.
                         sanitize_str(&mut message);
                         elog!(
-                            @information
+                            @info
                             "This message was attached to the offer:\n#### START MESSAGE ####\n{}\n#### END MESSAGE ####",
                             message
                         );
@@ -440,7 +440,7 @@ pub fn run_bet_cmd(
                     }
                 }
                 Plaintext::Messagev1(message) => {
-                    elog!(@information "The ciphertext contained a secret message: ");
+                    elog!(@info "The ciphertext contained a secret message: ");
                     Ok(item! { "message" => Cell::string(message) })
                 }
             }
@@ -465,7 +465,7 @@ pub fn run_bet_cmd(
                         for id in ids {
                             if let Err(e) = wallet.take_next_action(id, false) {
                                 elog!(
-                                    @explosion
+                                    @recoverable_error
                                     "Error updating state of bet {} after broadcasting claim tx {}: {}",
                                     id, txid, e
                                 );
@@ -496,7 +496,7 @@ pub fn run_bet_cmd(
                     for id in ids {
                         if let Err(e) = wallet.take_next_action(id, true) {
                             elog!(
-                                @explosion
+                                @recoverable_error
                                 "Error updating state of bet {} after broadcasting cancel tx: {}: {}",
                                 id, txid, e
                             );
@@ -506,7 +506,7 @@ pub fn run_bet_cmd(
                 output
             }
             None => {
-                elog!(@information "No bets needed canceling");
+                elog!(@info "No bets needed canceling");
                 CmdOutput::None
             }
         }),
@@ -532,7 +532,7 @@ pub fn run_bet_cmd(
                     Ok(None) => return Err(anyhow!("Bet {} doesn't exist", id)),
                     Err(_) => {
                         elog!(
-                            @information 
+                            @info
                             "Was unable to retrieve bet {} from the database. Assuming you know what you are doing and forgetting it.", 
                             id)
                         ;
@@ -687,7 +687,7 @@ pub fn run_bet_cmd(
                                 }
                             }
                             Plaintext::Messagev1(message) => {
-                                elog!(@information "This ciphertext contained a secret message:");
+                                elog!(@info "This ciphertext contained a secret message:");
                                 item! { "message" => Cell::string(message) }
                             }
                         }

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -342,7 +342,7 @@ pub fn run_bet_cmd(
                 }
                 None => read_input(
                     &format!(
-                        "The outcomes for this bet are\n{}\nWhich outcome would you like to to bet on?",
+                        "The outcomes for this bet are\n{}\nWhich outcome would you like to bet on?",
                         possible_outcomes
                             .iter()
                             .map(|o| format!(
@@ -466,7 +466,7 @@ pub fn run_bet_cmd(
                             if let Err(e) = wallet.take_next_action(id, false) {
                                 elog!(
                                     @explosion
-                                    "error updating state of bet {} after broadcasting claim tx {}: {}", 
+                                    "Error updating state of bet {} after broadcasting claim tx {}: {}", 
                                     id, txid, e
                                 );                            
                             }
@@ -497,7 +497,7 @@ pub fn run_bet_cmd(
                         if let Err(e) = wallet.take_next_action(id, true) {
                             elog!(
                                 @explosion
-                                "error updating state of bet {} after broadcasting cancel tx: {}: {}", 
+                                "Error updating state of bet {} after broadcasting cancel tx: {}: {}", 
                                 id, txid, e
                             );                        
                         }

--- a/src/cmd/bet.rs
+++ b/src/cmd/bet.rs
@@ -738,7 +738,7 @@ pub fn run_bet_cmd(
             if overflow > 0 && pad != 0 {
                 elog!(
                     @warning 
-                    "ciphertext is longer than {} by {} bytes so it will look unusually big",
+                    "Ciphertext is longer than {} by {} bytes so it will look unusually big",
                     pad, overflow
                 );
             }
@@ -931,7 +931,7 @@ fn bet_prompt(bet: &Bet, bet_verb: &str, you_paying_fee: bool) -> String {
     if you_paying_fee {
         writeln!(&mut res, "You are paying the fee.").unwrap();
     } else {
-        writeln!(&mut res, "you are NOT paying the fee.").unwrap();
+        writeln!(&mut res, "You are NOT paying the fee.").unwrap();
     }
     write!(&mut res, "Do you want to {} this bet", bet_verb).unwrap();
     res

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -606,9 +606,8 @@ macro_rules! eitem {
 #[macro_export]
 macro_rules! elog {
     (@warning $($tt:tt)*) => { eprint!("\u{26A0} "); eprintln!($($tt)*);};
-    (@information $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
+    (@info $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
     (@celebration $($tt:tt)*) => { eprint!("\u{1F389} "); eprintln!($($tt)*);};
-    (@suggestion $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
+    (@suggest $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
     (@explosion $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
-    (@water_pistol $($tt:tt)*) => { eprint!("\u{1F52B} "); eprintln!($($tt)*);};
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -603,7 +603,6 @@ macro_rules! eitem {
     }}
 }
 
-
 #[macro_export]
 macro_rules! elog {
     (@warning $($tt:tt)*) => { eprint!("\u{26A0} "); eprintln!($($tt)*);};

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub use wallet::*;
 use crate::{
     config::GunSigner,
     database::{ProtocolKind, StringDescriptor},
+    elog,
     keychain::ProtocolSecret,
     signers::{PsbtDirSigner, PwSeedSigner, XKeySigner},
     wallet::GunWallet,
@@ -91,14 +92,14 @@ pub fn read_yn(question: &str) -> bool {
     use std::io::{self, BufRead};
     let stdin = io::stdin();
     let mut lines = stdin.lock().lines();
-    eprint!("> {} [y/n]? ", question.replace('\n', "\n> "));
+    elog!(@question "{} [y/n]? ", question.replace('\n', "\n> "));
     lines
         .find_map(
             |line| match line.unwrap().trim_end().to_lowercase().as_str() {
                 "y" => Some(true),
                 "n" => Some(false),
                 _ => {
-                    eprint!("[y/n]? ");
+                    eprint!("> [y/n]? ");
                     None
                 }
             },
@@ -609,5 +610,7 @@ macro_rules! elog {
     (@info $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
     (@celebration $($tt:tt)*) => { eprint!("\u{1F389} "); eprintln!($($tt)*);};
     (@user_action $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
-    (@explosion $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
-}
+    (@recoverable_error $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
+    (@user_error $($tt:tt)*) => { eprint!("\u{274C}"); eprintln!($($tt)*);};
+    (@question $($tt:tt)*) => { eprint!("\u{2753}"); eprintln!($($tt)*); };
+    (@suggestion $($tt:tt)*) => { eprint!("\u{1F4A1}"); eprintln!($($tt)*); };}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -608,6 +608,6 @@ macro_rules! elog {
     (@warning $($tt:tt)*) => { eprint!("\u{26A0} "); eprintln!($($tt)*);};
     (@info $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
     (@celebration $($tt:tt)*) => { eprint!("\u{1F389} "); eprintln!($($tt)*);};
-    (@suggest $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
+    (@user_action $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
     (@explosion $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -602,3 +602,14 @@ macro_rules! eitem {
         $crate::cmd::CmdOutput::EmphasisedItem { main: ($main_key, $main_value), other: list }
     }}
 }
+
+
+#[macro_export]
+macro_rules! elog {
+    (@warning $($tt:tt)*) => { eprint!("\u{26A0} "); eprintln!($($tt)*);};
+    (@information $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
+    (@celebration $($tt:tt)*) => { eprint!("\u{1F389} "); eprintln!($($tt)*);};
+    (@suggestion $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
+    (@explosion $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
+    (@water_pistol $($tt:tt)*) => { eprint!("\u{1F52B} "); eprintln!($($tt)*);};
+}

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -1,4 +1,4 @@
-use crate::{cmd, database::GunDatabase, item, OracleInfo, Url, elog};
+use crate::{cmd, database::GunDatabase, elog, item, OracleInfo, Url};
 use anyhow::anyhow;
 use olivia_core::{http::RootResponse, OracleId};
 use olivia_secp256k1::Secp256k1;
@@ -41,7 +41,9 @@ pub fn run_oralce_cmd(gun_db: &GunDatabase, cmd: OracleOpt) -> anyhow::Result<Cm
                 .ok_or(anyhow!("Oracle url missing host"))?
                 .to_string();
             match gun_db.get_entity::<OracleInfo>(oracle_id.clone())? {
-                Some(_) => { elog!(@information "Oracle {} is already trusted", oracle_id); },
+                Some(_) => {
+                    elog!(@information "Oracle {} is already trusted", oracle_id);
+                }
                 None => {
                     let root_response = ureq::get(url.as_str())
                         .call()?

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -1,4 +1,4 @@
-use crate::{cmd, database::GunDatabase, item, OracleInfo, Url};
+use crate::{cmd, database::GunDatabase, item, OracleInfo, Url, elog};
 use anyhow::anyhow;
 use olivia_core::{http::RootResponse, OracleId};
 use olivia_secp256k1::Secp256k1;
@@ -38,10 +38,10 @@ pub fn run_oralce_cmd(gun_db: &GunDatabase, cmd: OracleOpt) -> anyhow::Result<Cm
                 Url::from_str(&url).or_else(|_| Url::from_str(&format!("https://{}", url)))?;
             let oracle_id = url
                 .host()
-                .ok_or(anyhow!("orcale url missing host"))?
+                .ok_or(anyhow!("Oracle url missing host"))?
                 .to_string();
             match gun_db.get_entity::<OracleInfo>(oracle_id.clone())? {
-                Some(_) => eprintln!("oracle {} is already trusted", oracle_id),
+                Some(_) => { elog!(@information "Oracle {} is already trusted", oracle_id); },
                 None => {
                     let root_response = ureq::get(url.as_str())
                         .call()?

--- a/src/cmd/oracle.rs
+++ b/src/cmd/oracle.rs
@@ -42,7 +42,7 @@ pub fn run_oralce_cmd(gun_db: &GunDatabase, cmd: OracleOpt) -> anyhow::Result<Cm
                 .to_string();
             match gun_db.get_entity::<OracleInfo>(oracle_id.clone())? {
                 Some(_) => {
-                    elog!(@information "Oracle {} is already trusted", oracle_id);
+                    elog!(@info "Oracle {} is already trusted", oracle_id);
                 }
                 None => {
                     let root_response = ureq::get(url.as_str())

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -182,7 +182,7 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
                     let passphrase_confirmation =
                         rpassword::prompt_password_stderr("Enter your wallet passphrase again:")?;
                     if !passphrase.eq(&passphrase_confirmation) {
-                        elog!(@explosion "Mismatching passphrases. Try again.\n");
+                        elog!(@user_error "Mismatching passphrases. Try again.\n");
                     } else {
                         break passphrase;
                     }

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -3,7 +3,8 @@ use crate::{
     cmd::{self},
     config::{Config, GunSigner},
     database::{GunDatabase, ProtocolKind, StringDescriptor},
-    keychain::ProtocolSecret, elog,
+    elog,
+    keychain::ProtocolSecret,
 };
 use anyhow::{anyhow, Context};
 use bdk::{

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -375,7 +375,7 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
         std::fs::write(path, content)?;
     }
 
-    elog!(@celebration "Successfully created walled at {}", wallet_dir.display());
+    elog!(@celebration "Successfully created wallet at {}", wallet_dir.display());
     Ok(CmdOutput::None)
 }
 

--- a/src/cmd/setup.rs
+++ b/src/cmd/setup.rs
@@ -3,7 +3,7 @@ use crate::{
     cmd::{self},
     config::{Config, GunSigner},
     database::{GunDatabase, ProtocolKind, StringDescriptor},
-    keychain::ProtocolSecret,
+    keychain::ProtocolSecret, elog,
 };
 use anyhow::{anyhow, Context};
 use bdk::{
@@ -173,15 +173,15 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
             };
 
             let passphrase = if use_passphrase {
-                eprintln!("WARNING: If you lose or forget your passphrase, you will lose access to your funds.");
-                eprintln!("WARNING: You MUST store your passphrase with your seed words in order to make a complete backup.");
+                elog!(@warning "If you lose or forget your passphrase, you will lose access to your funds.");
+                elog!(@warning "You MUST store your passphrase with your seed words in order to make a complete backup.");
                 loop {
                     let passphrase =
                         rpassword::prompt_password_stderr("Enter your wallet passphrase:")?;
                     let passphrase_confirmation =
                         rpassword::prompt_password_stderr("Enter your wallet passphrase again:")?;
                     if !passphrase.eq(&passphrase_confirmation) {
-                        eprintln!("Mismatching passphrases. Try again.\n")
+                        elog!(@explosion "Mismatching passphrases. Try again.\n");
                     } else {
                         break passphrase;
                     }
@@ -200,7 +200,8 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
                     .join("\n");
                 println!("{}", printed);
             } else {
-                eprintln!(
+                elog!(
+                    @suggestion
                     "Err okay then...make sure you backup {} after this.",
                     sw_file.display()
                 );
@@ -373,7 +374,7 @@ pub fn run_setup(wallet_dir: &std::path::Path, cmd: SetupOpt) -> anyhow::Result<
         std::fs::write(path, content)?;
     }
 
-    eprintln!("Successfully created walled at {}", wallet_dir.display());
+    elog!(@celebration "Successfully created walled at {}", wallet_dir.display());
     Ok(CmdOutput::None)
 }
 

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{amount_ext::FromCliStr, betting::BetState, cmd, item, elog};
+use crate::{amount_ext::FromCliStr, betting::BetState, cmd, elog, item};
 use bdk::{
     bitcoin::{Address, OutPoint, Script, Transaction, Txid},
     blockchain::EsploraBlockchain,

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -340,7 +340,7 @@ impl SpendOpt {
                 for bet_id in claiming_bet_ids {
                     if let Err(e) = wallet.take_next_action(bet_id, false) {
                         elog!(
-                            @explosion
+                            @recoverable_error
                             "Error updating state of bet {} after broadcasting claim tx {}: {}",
                             bet_id, txid, e
                         );

--- a/src/cmd/wallet.rs
+++ b/src/cmd/wallet.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{amount_ext::FromCliStr, betting::BetState, cmd, item};
+use crate::{amount_ext::FromCliStr, betting::BetState, cmd, item, elog};
 use bdk::{
     bitcoin::{Address, OutPoint, Script, Transaction, Txid},
     blockchain::EsploraBlockchain,
@@ -67,7 +67,7 @@ pub fn run_balance(wallet: &GunWallet, sync: bool) -> anyhow::Result<CmdOutput> 
     );
 
     if !sync && (confirmed + unconfirmed + unclaimed + in_bet + in_use == Amount::ZERO) {
-        eprintln!("Remember to sync gun with -s or --sync to ensure balances are up to date. i.e. run `gun -s balance` ");
+        elog!(@suggestion "Remember to sync gun with -s or --sync to ensure balances are up to date. i.e. run `gun -s balance` ");
     }
 
     Ok(item! {
@@ -339,8 +339,9 @@ impl SpendOpt {
             if !print_tx {
                 for bet_id in claiming_bet_ids {
                     if let Err(e) = wallet.take_next_action(bet_id, false) {
-                        eprintln!(
-                            "error updating state of bet {} after broadcasting claim tx {}: {}",
+                        elog!(
+                            @explosion
+                            "Error updating state of bet {} after broadcasting claim tx {}: {}",
                             bet_id, txid, e
                         );
                     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, keychain::ProtocolSecret, OracleInfo, elog};
+use crate::{betting::*, elog, keychain::ProtocolSecret, OracleInfo};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::OutPoint,

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, keychain::ProtocolSecret, OracleInfo};
+use crate::{betting::*, keychain::ProtocolSecret, OracleInfo, elog};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::OutPoint,
@@ -233,7 +233,7 @@ impl GunDatabase {
         self.list_entities().filter_map(|entity| match entity {
             Ok(entity) => Some(entity),
             Err(e) => {
-                eprintln!("Error retreiving an {}: {}", T::name(), e);
+                elog!(@explosion "Error retreiving an {}: {}", T::name(), e);
                 None
             }
         })

--- a/src/database.rs
+++ b/src/database.rs
@@ -233,7 +233,7 @@ impl GunDatabase {
         self.list_entities().filter_map(|entity| match entity {
             Ok(entity) => Some(entity),
             Err(e) => {
-                elog!(@explosion "Error retreiving an {}: {}", T::name(), e);
+                elog!(@recoverable_error "Error retreiving an {}: {}", T::name(), e);
                 None
             }
         })

--- a/src/signers.rs
+++ b/src/signers.rs
@@ -14,7 +14,10 @@ use bdk::{
 };
 use miniscript::bitcoin::{PrivateKey, PublicKey};
 
-use crate::{cmd::{display_psbt, read_yn}, elog};
+use crate::{
+    cmd::{display_psbt, read_yn},
+    elog,
+};
 
 #[derive(Debug)]
 pub struct XKeySigner {

--- a/src/signers.rs
+++ b/src/signers.rs
@@ -111,7 +111,7 @@ impl Signer for PwSeedSigner {
             let passphrase = match p {
                 Ok(passphrase) => passphrase,
                 Err(e) => {
-                    elog!(@explosion "Failed to read in password: {}", e);
+                    elog!(@recoverable_error "Failed to read in password: {}", e);
                     return Err(SignerError::InvalidKey);
                 }
             };
@@ -120,7 +120,7 @@ impl Signer for PwSeedSigner {
             let master_xkey = xkey.into_xprv(self.network).unwrap();
 
             if master_xkey.fingerprint(secp) != self.master_fingerprint {
-                elog!(@explosion "Invalid passphrase, derived fingerprint does not match. Try again.");
+                elog!(@recoverable_error "Invalid passphrase, derived fingerprint does not match. Try again.");
             } else {
                 break master_xkey;
             }
@@ -184,7 +184,7 @@ impl Signer for PsbtDirSigner {
                 let _ = std::io::stdin().read_line(&mut String::new());
             } else if let Err(e) = std::fs::write(&psbt_file, psbt.to_string()) {
                 elog!(
-                    @explosion
+                    @recoverable_error
                     "Was unable to write PSBT {}: {}\nPress enter to try again.",
                     psbt_file.display(),
                     e
@@ -201,9 +201,9 @@ impl Signer for PsbtDirSigner {
             self.path.as_path().join(format!("{}-signed.psbt", txid)),
             self.path.as_path().join(format!("{}-part.psbt", txid)),
         ];
-        elog!(@information "gun will look for the signed psbt files at:",);
+        elog!(@info "gun will look for the signed psbt files at:",);
         for location in &file_locations {
-            elog!(@information "{}", location.display());
+            elog!(@info "{}", location.display());
         }
         elog!(@suggestion "Press enter once signed.");
         let (signed_psbt_path, contents) = loop {
@@ -221,7 +221,7 @@ impl Signer for PsbtDirSigner {
                 }
                 None => {
                     elog!(
-                        @explosion
+                        @recoverable_error
                         "Couldn't read any of the files: {}\n",
                         file_contents.remove(0).1.unwrap_err()
                     );
@@ -232,8 +232,8 @@ impl Signer for PsbtDirSigner {
 
         match psbt_result {
             Err(e) => {
-                elog!(@explosion "Failed to parse PSBT file {}", signed_psbt_path.display());
-                elog!(@explosion "{}", e);
+                elog!(@recoverable_error "Failed to parse PSBT file {}", signed_psbt_path.display());
+                elog!(@recoverable_error "{}", e);
                 Err(SignerError::UserCanceled)
             }
             Ok(read_psbt) => {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -275,7 +275,7 @@ impl GunWallet {
             match self.take_next_action(bet_id, true) {
                 Ok(_updated) => {}
                 Err(e) => {
-                    elog!(@explosion "Error trying to take action on bet {}: {:?}", bet_id, e);
+                    elog!(@recoverable_error "Error trying to take action on bet {}: {:?}", bet_id, e);
                 }
             }
         }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,4 +1,6 @@
-use crate::{betting::*, database::GunDatabase, signers::PSBT_SIGNER_ID, FeeSpec, OracleInfo, elog};
+use crate::{
+    betting::*, database::GunDatabase, elog, signers::PSBT_SIGNER_ID, FeeSpec, OracleInfo,
+};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{
@@ -274,7 +276,7 @@ impl GunWallet {
                 Ok(_updated) => {}
                 Err(e) => {
                     elog!(@explosion "Error trying to take action on bet {}: {:?}", bet_id, e);
-                }           
+                }
             }
         }
     }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,4 +1,4 @@
-use crate::{betting::*, database::GunDatabase, signers::PSBT_SIGNER_ID, FeeSpec, OracleInfo};
+use crate::{betting::*, database::GunDatabase, signers::PSBT_SIGNER_ID, FeeSpec, OracleInfo, elog};
 use anyhow::{anyhow, Context};
 use bdk::{
     bitcoin::{
@@ -272,7 +272,9 @@ impl GunWallet {
         for (bet_id, _) in self.gun_db().list_entities_print_error::<BetState>() {
             match self.take_next_action(bet_id, true) {
                 Ok(_updated) => {}
-                Err(e) => eprintln!("Error trying to take action on bet {}: {:?}", bet_id, e),
+                Err(e) => {
+                    elog!(@explosion "Error trying to take action on bet {}: {:?}", bet_id, e);
+                }           
             }
         }
     }


### PR DESCRIPTION
This adds a macro for printing out to stdout, makes spelling (all uppercase) consistent and spelling errors.

The following emojis are 
⚠️ 
    (@warning $($tt:tt)*) => { eprint!("\u{26A0} "); eprintln!($($tt)*);};
ℹ️ 
    (@information $($tt:tt)*) => { eprint!("\u{2139} "); eprintln!($($tt)*);};
🎉 
    (@celebration $($tt:tt)*) => { eprint!("\u{1F389} "); eprintln!($($tt)*);};
👉🏼 
    (@suggestion $($tt:tt)*) => { eprint!("\u{1F449} "); eprintln!($($tt)*);};
💥 
    (@explosion $($tt:tt)*) => { eprint!("\u{1F4A5} "); eprintln!($($tt)*);};
🔫 
    (@water_pistol $($tt:tt)*) => { eprint!("\u{1F52B} "); eprintln!($($tt)*);};
